### PR TITLE
Fix cz-tmux theme with shell script

### DIFF
--- a/tmux-cz.sh
+++ b/tmux-cz.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # {{{ color
 black="colour0"
 white="colour15"
@@ -14,11 +16,11 @@ light_gray="colour243"
 
 # {{{ status
 # options
-set -g status-interval 1
-set -g status-justify left
+tmux set -g status-interval 1
+tmux set -g status-justify left
 
 # base color
-set -g status-style bg=$light_black,fg=$dark_orange
+tmux set -g status-style bg=$light_black,fg=$dark_orange
 # }}}
 
 # {{{ window status
@@ -28,8 +30,8 @@ window_name="#[bg=$dark_gray] #{window_name} "
 cur_window_index="#[bg=$yellow_green]#[fg=$black] #{window_index}#{window_flags} "
 cur_window_name="#[bg=$navajo_white] #{window_name} "
 
-set -g window-status-format "${window_index}${window_name}"
-set -g window-status-current-format "${cur_window_index}${cur_window_name}"
+tmux set -g window-status-format "${window_index}${window_name}"
+tmux set -g window-status-current-format "${cur_window_index}${cur_window_name}"
 # }}}
 
 # {{{ left and right status
@@ -50,30 +52,31 @@ battery_status="${dark_gray_block}#{battery_status_fg}#{battery_icon} #{battery_
 clock="#[bg=$dark_gray] %H:%M %Y-%m-%d(%a) "
 status_right="${clock}${default_block}${color_blocks_reverse}"
 
-set -g status-left-length 90
-set -g status-left "${color_blocks}${default_block}${host_name}${default_block}"
-set -g status-right-length 90
+tmux set -g status-left-length 90
+tmux set -g status-left "${color_blocks}${default_block}${host_name}${default_block}"
+tmux set -g status-right-length 90
 
 # If 
-set -g status-right "${battery_status}${default_block}${status_right}"
-if -b "! tmux show-option -gqv @plugin | grep tmux-battery" \
-  'set -g status-right "${status_right}"'
+tmux set -g status-right "${status_right}"
+if tmux show-option -gqv @plugin | grep tmux-battery > /dev/null 2>&1; then
+  tmux set -g status-right "${battery_status}${default_block}${status_right}"
+fi
 # }}}
 
 # {{{ pane
-set -g pane-border-style fg=$dark_gray
-set -g pane-active-border-style fg=$dark_orange
+tmux set -g pane-border-style fg=$dark_gray
+tmux set -g pane-active-border-style fg=$dark_orange
 # }}}
 
 # {{{ mode
-set -g mode-style bg=$dark_orange,fg=$light_black
+tmux set -g mode-style bg=$dark_orange,fg=$light_black
 # }}}
 
 # {{{ message
-set -g message-style bg=$light_black,fg=$dark_orange
+tmux set -g message-style bg=$light_black,fg=$dark_orange
 # }}}
 
 # {{{ display pane number
-set -g display-panes-colour $yellow_green
-set -g display-panes-active-colour $dark_orange
+tmux set -g display-panes-colour $yellow_green
+tmux set -g display-panes-active-colour $dark_orange
 # }}}

--- a/tmux-cz.tmux
+++ b/tmux-cz.tmux
@@ -4,7 +4,9 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 main() {
   local theme='cz'
-  tmux source-file "$CURRENT_DIR"/tmux.$theme.conf
+
+  # shellcheck source=/dev/null
+  source "$CURRENT_DIR"/tmux-$theme.sh
 }
 
 main


### PR DESCRIPTION
Prevent adding environment variables to shell. The environment
variables define color code, status bar format to tmux-cz.But it is no
need for shell.